### PR TITLE
fix: 修复 getCookie 方法中的p_skey解析错误

### DIFF
--- a/packages/napcat-sdk/src/napcat.ts
+++ b/packages/napcat-sdk/src/napcat.ts
@@ -823,7 +823,7 @@ export class NapCat {
     const { cookies: cookieString, bkn } = await this.getNapCatCookies(domain)
 
     const skey = cookieString.match(/skey=([^;]*)/)?.[1] || ''
-    const pskey = cookieString.match(/pskey=([^;]*)/)?.[1] || ''
+    const pskey = cookieString.match(/p_skey=([^;]*)/)?.[1] || ''
     const gtk = this.getGTk(pskey)
 
     const returns = {


### PR DESCRIPTION
napcat.ts修改const pskey = cookieString.match(/pskey=([^;]*)/)?.[1] || ''为const pskey = cookieString.match(/p_skey=([^;]*)/)?.[1] || ''