### PR TITLE
fix: 修复多 NapCat 实例连接时 ctx.bot 指向错误的问题

### DIFF
--- a/packages/mioki/src/plugin.ts
+++ b/packages/mioki/src/plugin.ts
@@ -27,6 +27,8 @@ import type { ScheduledTask, TaskContext } from 'node-cron'
 import type { ConsolaInstance } from 'consola/core'
 import type { ExtendedNapCat } from './start'
 
+// 当前事件处理的 bot holder
+const currentBotHolder: { bot: ExtendedNapCat | null } = { bot: null }
 type Num = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
 
 type Utils = typeof utilsExports
@@ -263,10 +265,22 @@ export const runtimePlugins: Map<
   }
 >()
 
-const buildRemovedActions = (bot: NapCat) =>
-  Object.fromEntries(
-    Object.entries(actionsExports).map(([k, v]) => [k, bindBot(bot, v as any)]),
-  ) as RemoveBotParam<Actions>
+const buildRemovedActions = (_bot: NapCat) => {
+  const handler = {
+    get: function (target: any, prop: string) {
+      if (prop === 'bindBot' || prop === 'getBot') {
+        return target[prop]
+      }
+      const fn = target[prop]
+      if (typeof fn === 'function') {
+        return (...args: any[]) => fn(currentBotHolder.bot || _bot, ...args)
+      }
+      return fn
+    },
+  }
+  const proxy = new Proxy(actionsExports, handler)
+  return proxy as RemoveBotParam<Actions>
+}
 
 /**
  * 检查事件是否是群消息事件
@@ -397,9 +411,13 @@ export async function enablePlugin(
     // 为每个 bot 创建上下文
     const createContext = (bot: ExtendedNapCat): MiokiContext => {
       return {
-        bot,
+        get bot() {
+          return currentBotHolder.bot || bot
+        },
         bots,
-        self_id: bot.bot_id,
+        get self_id() {
+          return currentBotHolder.bot?.bot_id || bot.bot_id
+        },
         segment: bot.segment,
         getCookie: bot.getCookie.bind(bot),
         ...utilsExports,
@@ -457,7 +475,14 @@ export async function enablePlugin(
                 deduplicator.markProcessed(e, dedupeScope)
               }
 
-              handler(e)
+              // 设置当前 bot 并执行 handler
+              const prevBot = currentBotHolder.bot
+              currentBotHolder.bot = bot
+              try {
+                handler(e)
+              } finally {
+                currentBotHolder.bot = prevBot
+              }
             }
 
             bot.on(eventName, wrappedHandler)


### PR DESCRIPTION
#### 问题

当连接多个 NapCat 实例时，插件中通过 `ctx.bot` 调用发送消息等接口时，会错误地使用第一个连接的 bot 实例，而不是收到消息的那个 bot

#### 复现

1. 配置 `package.json` 中的 `napcat` 数组，连接两个 `NapCat` 实例
2. 让 bot1 加入某个群，bot2 不加入该群
3. 在群里发送消息触发插件处理
4. 插件调用 `ctx.bot.sendGroupMsg()` 或其他接口操作

#### 报错: 

```bash
[17:07:24] ERROR [mioki] unhandledRejection, 出错了: Error: API 错误: EventChecker Failed: NTEvent serviceAndMethod:NodeIKernelMsgService/sendMsg ListenerName:NodeIKernelMsgListener/onMsgInfoListUpdate EventRet:
{
    "result": 110,
    "errMsg": "发送失败，你已被移出该群，请重新加群。"
}
```
#### 修复

- 引入 `currentBotHolder` 记录当前处理事件的 bot
- 将 `ctx.bot` 和 `ctx.self_id` 改为 `getter`，动态返回正确的 bot
