### PR TITLE
Bugfix

### DIFF
--- a/docs/napcat-sdk/event.md
+++ b/docs/napcat-sdk/event.md
@@ -366,7 +366,7 @@ napcat.on('notice.group.increase', (event) => {
 | 属性 | 类型 | 说明 |
 | --- | --- | --- |
 | `operator_id` | `number` | 操作者 QQ 号（邀请者） |
-| `actions_type` | `string` | 加入方式：`invite`、`add`、`approve` |
+| `action_type` | `string` | 加入方式：`invite`、`add`、`approve` |
 
 ### notice.group.decrease
 
@@ -375,7 +375,7 @@ napcat.on('notice.group.increase', (event) => {
 ```ts
 napcat.on('notice.group.decrease', (event) => {
   console.log(`${event.user_id} 离开了群 ${event.group_id}`)
-  console.log(`离开方式: ${event.actions_type}`) // 'kick' | 'leave'
+  console.log(`离开方式: ${event.action_type}`) // 'kick' | 'leave'
 })
 ```
 
@@ -384,7 +384,7 @@ napcat.on('notice.group.decrease', (event) => {
 | 属性 | 类型 | 说明 |
 | --- | --- | --- |
 | `operator_id` | `number` | 操作者 QQ 号 |
-| `actions_type` | `string` | 离开方式：`kick`（被踢）、`leave`（主动退出） |
+| `action_type` | `string` | 离开方式：`kick`（被踢）、`leave`（主动退出） |
 
 ### notice.group.admin
 

--- a/packages/mioki/src/plugin.ts
+++ b/packages/mioki/src/plugin.ts
@@ -450,18 +450,16 @@ export async function enablePlugin(
                 }
               }
 
-              // 过滤来自连接实例的事件
-              const senderUserId = e.user_id
-              const senderOperatorId = e.operator_id
+              // 只过滤消息事件中的连接实例
+              if (isMessageEvent(e)) {
+                const messageEvent = e as MessageEvent
+                const senderUserId = messageEvent.user_id
+                const isFromConnectedBot = senderUserId && bots.some((b) => b.bot_id === senderUserId)
 
-              // 检查发送者是否为连接的实例
-              const isFromConnectedBot = senderUserId && bots.some((b) => b.bot_id === senderUserId)
-              const isFromConnectedBotOperator = senderOperatorId && bots.some((b) => b.bot_id === senderOperatorId)
-
-              if (isFromConnectedBot || isFromConnectedBotOperator) {
-                return
+                if (isFromConnectedBot) {
+                  return
+                }
               }
-
               // 根据选项决定是否去重
               if (deduplicate && isDeduplicableEvent(e)) {
                 if (deduplicator.isProcessed(e, dedupeScope)) {

--- a/packages/napcat-sdk/src/types.ts
+++ b/packages/napcat-sdk/src/types.ts
@@ -987,7 +987,7 @@ export type GroupIncreaseNoticeEvent = GroupNoticeEventBase<
     /** 操作者 QQ 号（如邀请者） */
     operator_id: number
     /** 加入类型：invite-邀请, add-主动加群, approve-管理员审批 */
-    actions_type: 'invite' | 'add' | 'approve'
+    action_type: 'invite' | 'add' | 'approve'
   }
 >
 
@@ -998,7 +998,7 @@ export type GroupDecreaseNoticeEvent = GroupNoticeEventBase<
     /** 操作者 QQ 号 */
     operator_id: number
     /** 离开类型：kick-被踢, leave-主动退出 */
-    actions_type: 'kick' | 'leave'
+    action_type: 'leave' | 'kick' | 'kick_me' | 'disband'
   }
 >
 


### PR DESCRIPTION
## 错误修复

- `plugin.ts` 事件过滤

过滤器用于防止自身消息被触发，但只应过滤`message`事件，否则像`notice.group.ban`或`decrease`等事件在target为bot自身时会被提前return

- `napcat-sdk` 类型命名与运行时字段不一致

类型声明使用 `actions_type`，但运行时实际写入的是 `action_type`

- `napcat-sdk` `group_decrease` 事件类型缺失

对比[NapCat官方文档](https://www.napcat.wiki/onebot/basic_event)补齐为`leave | kick | kick_me | disband`
