### PR TITLE
修复发消息统计数量为0问题 细节修复

### DIFF
--- a/packages/mioki/src/builtins/core/status.ts
+++ b/packages/mioki/src/builtins/core/status.ts
@@ -182,23 +182,23 @@ export async function formatMiokiStatus(status: MiokiStatus): Promise<string> {
 
   const botLines = bots
     .map((bot) => {
-      return `👤 ${bot.nickname} (${bot.uin})\n   📋 ${localNum(bot.friends)} 好友 / ${localNum(bot.groups)} 群 / 📮 收 ${localNum(bot.receive)} 发 ${localNum(bot.send)}`
+      return `👤${bot.nickname}(${bot.uin})\n📋${localNum(bot.friends)}好友/${localNum(bot.groups)}群/📮收${localNum(bot.receive)}发${localNum(bot.send)}`
     })
     .join('\n')
 
-  const statsLine = bots.length > 1 ? `\n📮 总计: 收 ${localNum(stats.receive)} 条，发 ${localNum(stats.send)} 条` : ''
+  const statsLine = bots.length > 1 ? `\n📮总计:收${localNum(stats.receive)}条，发${localNum(stats.send)}条` : ''
 
   return `
-〓 🟢 mioki 状态 〓
+〓🟢mioki状态〓
 ${botLines}
-🧩 启用了 ${localNum(plugins.enabled)} 个插件，共 ${localNum(plugins.total)} 个${statsLine}
-🚀 ${filesize(memory.rss.used, { round: 1 })}/${memory.percent}%
-⏳ 已运行 ${prettyMs(stats.uptime, { hideYear: true, secondsDecimalDigits: 0 })}
-🤖 mioki/${versions.mioki}-NapCat/${versions.napcat}
-🖥️ ${system.name.split(' ')[0]}/${system.version.split('.')[0]}-${system.name}-node/${versions.node.split('.')[0]}
-📊 ${memory.percent}%-${filesize(memory.used, { base: 2, round: 1 })}/${filesize(memory.total, { base: 2, round: 1 })}
-🧮 ${cpu.percent}%-${cpu.name}-${cpu.count}核
-${diskValid ? `💾 ${diskDesc}` : ''}
+🧩启用了${localNum(plugins.enabled)}个插件，共${localNum(plugins.total)}个${statsLine}
+🚀${filesize(memory.rss.used, { round: 1 })}/${memory.percent}%
+⏳已运行${prettyMs(stats.uptime, { hideYear: true, secondsDecimalDigits: 0 })}
+🤖mioki/${versions.mioki}-NapCat/${versions.napcat}
+🖥️${system.name.split(' ')[0]}/${system.version.split('.')[0]}-${system.name}-node/${versions.node.split('.')[0]}
+📊${memory.percent}%-${filesize(memory.used, { base: 2, round: 1 })}/${filesize(memory.total, { base: 2, round: 1 })}
+🧮${cpu.percent}%-${cpu.name}-${cpu.count}核
+${diskValid ? `💾${diskDesc}` : ''}
   `.trim()
 }
 

--- a/packages/mioki/src/builtins/core/status.ts
+++ b/packages/mioki/src/builtins/core/status.ts
@@ -182,23 +182,23 @@ export async function formatMiokiStatus(status: MiokiStatus): Promise<string> {
 
   const botLines = bots
     .map((bot) => {
-      return `👤${bot.nickname}(${bot.uin})\n📋${localNum(bot.friends)}好友/${localNum(bot.groups)}群/📮收${localNum(bot.receive)}发${localNum(bot.send)}`
+      return `👤 ${bot.nickname} (${bot.uin})\n📋 ${localNum(bot.friends)} 好友 / ${localNum(bot.groups)} 群 / 📮 收 ${localNum(bot.receive)} 发 ${localNum(bot.send)}`
     })
     .join('\n')
 
-  const statsLine = bots.length > 1 ? `\n📮总计:收${localNum(stats.receive)}条，发${localNum(stats.send)}条` : ''
+  const statsLine = bots.length > 1 ? `\n📮 总计: 收 ${localNum(stats.receive)} 条，发 ${localNum(stats.send)} 条` : ''
 
   return `
-〓🟢mioki状态〓
+〓 🟢 mioki 状态 〓
 ${botLines}
-🧩启用了${localNum(plugins.enabled)}个插件，共${localNum(plugins.total)}个${statsLine}
-🚀${filesize(memory.rss.used, { round: 1 })}/${memory.percent}%
-⏳已运行${prettyMs(stats.uptime, { hideYear: true, secondsDecimalDigits: 0 })}
-🤖mioki/${versions.mioki}-NapCat/${versions.napcat}
-🖥️${system.name.split(' ')[0]}/${system.version.split('.')[0]}-${system.name}-node/${versions.node.split('.')[0]}
-📊${memory.percent}%-${filesize(memory.used, { base: 2, round: 1 })}/${filesize(memory.total, { base: 2, round: 1 })}
-🧮${cpu.percent}%-${cpu.name}-${cpu.count}核
-${diskValid ? `💾${diskDesc}` : ''}
+🧩 启用了 ${localNum(plugins.enabled)} 个插件，共 ${localNum(plugins.total)} 个${statsLine}
+🚀 ${filesize(memory.rss.used, { round: 1 })}/${memory.percent}%
+⏳ 已运行 ${prettyMs(stats.uptime, { hideYear: true, secondsDecimalDigits: 0 })}
+🤖 mioki/${versions.mioki}-NapCat/${versions.napcat}
+🖥️ ${system.name.split(' ')[0]}/${system.version.split('.')[0]}-${system.name}-node/${versions.node.split('.')[0]}
+📊 ${memory.percent}%-${filesize(memory.used, { base: 2, round: 1 })}/${filesize(memory.total, { base: 2, round: 1 })}
+🧮 ${cpu.percent}%-${cpu.name}-${cpu.count}核
+${diskValid ? `💾 ${diskDesc}` : ''}
   `.trim()
 }
 

--- a/packages/mioki/src/start.ts
+++ b/packages/mioki/src/start.ts
@@ -61,6 +61,10 @@ async function connectBot(config: cfg.NapCatInstanceConfig, index: number): Prom
       extendedNapCat.app_name = app_name
       extendedNapCat.app_version = app_version
 
+      const removeFromRegistry = () => connectedBots.delete(user_id)
+      napcat.on('napcat.closing', removeFromRegistry)
+      napcat.on('napcat.reconnect_failed', removeFromRegistry)
+
       resolve(extendedNapCat)
     })
 

--- a/packages/napcat-sdk/src/napcat.ts
+++ b/packages/napcat-sdk/src/napcat.ts
@@ -526,12 +526,11 @@ export class NapCat {
           break
         }
 
+        // TODO message_sent 是否有意义
         case 'message_sent': {
           if (data.message_type === 'private') {
-            this.#stat.send.private++
             data = this.#buildPrivateMessageEvent(data)
           } else {
-            this.#stat.send.group++
             data = this.#buildGroupMessageEvent(data)
           }
 
@@ -860,6 +859,7 @@ export class NapCat {
    * 发送私聊消息
    */
   sendPrivateMsg(user_id: number, sendable: Arrayable<Sendable>): Promise<{ message_id: number }> {
+    this.#stat.send.private++
     return this.api<{ message_id: number }>('send_private_msg', {
       user_id,
       message: this.normalizeSendable(sendable),
@@ -870,6 +870,7 @@ export class NapCat {
    * 发送群消息
    */
   sendGroupMsg(group_id: number, sendable: Arrayable<Sendable>): Promise<{ message_id: number }> {
+    this.#stat.send.group++
     return this.api<{ message_id: number }>('send_group_msg', {
       group_id,
       message: this.normalizeSendable(sendable),


### PR DESCRIPTION
## 修复

- 从接收`message_sent`记录发送消息数量改为在调用`send_message`时主动记录

> NapCat 文档中没有查到有`message_sent`这样的用法

- 已连接NapCat列表中删除失效的实例

## 优化

- 优化状态显示排版